### PR TITLE
:bug: returning wrong totalSupply

### DIFF
--- a/src/BaseGen.sol
+++ b/src/BaseGen.sol
@@ -106,7 +106,7 @@ contract BaseGen is ERC721, ERC721Burnable, ERC721Royalty, Ownable {
     function safeMint(address to) public payable {
         uint256 tokenId = _nextTokenId++;
 
-        if (tokenId > _maxSupply) {
+        if (tokenId >= _maxSupply) {
             revert MintQuantityExceedsMaxSupply(tokenId, _maxSupply);
         }
 

--- a/test/BaseGen.t.sol
+++ b/test/BaseGen.t.sol
@@ -7,10 +7,11 @@ import "../src/BaseGen.sol";
 // https://hackernoon.com/implementing-the-erc-2981-nft-royalty-standard-with-solidity
 contract BaseGenTest is Test {
     BaseGen public instance;
-    uint256 public constant pricePerMint = 0.01 ether;
+    uint256 public constant pricePerMint = 0.0015 ether;
+    address public initialOwner;
 
     function setUp() public {
-        address initialOwner = vm.addr(1);
+        initialOwner = vm.addr(1);
         string memory name = "Generative";
         string memory symbol = "GEN";
         string memory contractURI = "ipfs://";
@@ -18,9 +19,7 @@ contract BaseGenTest is Test {
         uint256 maxSupply = 256;
         address receiver = vm.addr(2);
         instance = new BaseGen(initialOwner, name, symbol, contractURI, baseURI, maxSupply, receiver);
-        // instance.safeMint(initialOwner);
         instance.safeMint{value: pricePerMint}(initialOwner);
-        // instance.setMaxSupply(128);
     }
 
     function testName() public view {
@@ -49,5 +48,86 @@ contract BaseGenTest is Test {
     function testValue() public view {
         address receiver = vm.addr(2);
         assertEq(receiver.balance, pricePerMint / 2);
+    }
+
+    function testTotalSupply() public {
+        assertEq(instance.totalSupply(), 1);
+        
+        // Mint another token
+        vm.deal(address(0x123), pricePerMint); // Ensure the address has enough ETH
+        vm.prank(address(0x123));
+        instance.safeMint{value: pricePerMint}(address(0x123));
+        
+        assertEq(instance.totalSupply(), 2);
+
+        // Mint some tokens
+        for (uint256 i = 0; i < 5; i++) {
+            vm.deal(address(0x123), pricePerMint); // Ensure the address has enough ETH
+            vm.prank(address(0x123));
+            instance.safeMint{value: pricePerMint}(address(0x123));
+        }
+
+        assertEq(instance.totalSupply(), 7);
+    }
+
+    function testMaxSupply() public {
+        assertEq(instance.maxSupply(), 256);
+        
+        // Test changing max supply
+        vm.prank(initialOwner);
+        instance.setMaxSupply(128);
+        assertEq(instance.maxSupply(), 128);
+    }
+
+    function testMintExceedsMaxSupply() public {
+        // Get the current max supply
+        uint256 initialMaxSupply = instance.maxSupply();
+        
+        // Set a new, lower max supply
+        uint256 newMaxSupply = 10;
+        vm.prank(initialOwner);
+        instance.setMaxSupply(newMaxSupply);
+        
+        // Verify the new max supply
+        assertEq(instance.maxSupply(), newMaxSupply);
+        
+        // Mint tokens until we reach one less than the new max supply
+        for (uint256 i = instance.totalSupply(); i < newMaxSupply - 1; i++) {
+            vm.deal(address(0x123), pricePerMint);
+            vm.prank(address(0x123));
+            instance.safeMint{value: pricePerMint}(address(0x123));
+        }
+        
+        // Verify we're at one less than new max supply
+        assertEq(instance.totalSupply(), newMaxSupply - 1);
+        
+        // Mint one more token, which should succeed
+        vm.deal(address(0x456), pricePerMint);
+        vm.prank(address(0x456));
+        instance.safeMint{value: pricePerMint}(address(0x456));
+        
+        // Verify we've reached new max supply
+        assertEq(instance.totalSupply(), newMaxSupply);
+        
+        // Now try to mint one more token, which should revert
+        vm.deal(address(0x789), pricePerMint);
+        vm.prank(address(0x789));
+        vm.expectRevert();
+        instance.safeMint{value: pricePerMint}(address(0x789));
+        
+        // Try to set max supply lower than current total supply, which should revert
+        vm.prank(initialOwner);
+        vm.expectRevert();
+        instance.setMaxSupply(newMaxSupply - 1);
+        
+        // Verify max supply hasn't changed
+        assertEq(instance.maxSupply(), newMaxSupply);
+        
+        // Set max supply back to initial value
+        vm.prank(initialOwner);
+        instance.setMaxSupply(initialMaxSupply);
+        
+        // Verify max supply has been restored
+        assertEq(instance.maxSupply(), initialMaxSupply);
     }
 }


### PR DESCRIPTION
### Context 

as @preschian mentioned - https://github.com/kodadot/nft-gallery/blob/main/utils/onchain/evm.ts

Base Gen was returning wrong totalSupply as I confused it with max supply,
This PR fixes it